### PR TITLE
Fix broken links

### DIFF
--- a/packages/docusaurus-1.x/lib/server/metadataUtils.js
+++ b/packages/docusaurus-1.x/lib/server/metadataUtils.js
@@ -70,7 +70,7 @@ function mdToHtml(Metadata, siteConfig) {
   const result = {};
   Object.keys(Metadata).forEach(id => {
     const metadata = Metadata[id];
-    if (metadata.language !== 'en' || metadata.original_id) {
+    if (metadata.language !== 'en') {
       return;
     }
     let htmlLink = baseUrl + metadata.permalink.replace('/next/', '/');
@@ -78,7 +78,7 @@ function mdToHtml(Metadata, siteConfig) {
     const baseDocsPart = `${baseUrl}${docsUrl ? `${docsUrl}/` : ''}`;
 
     const i18nDocsRegex = new RegExp(`^${baseDocsPart}en/`);
-    const docsRegex = new RegExp(`^${baseDocsPart}`);
+    const docsRegex = new RegExp(`^${baseDocsPart}(${metadata.version}/)?`);
     if (i18nDocsRegex.test(htmlLink)) {
       htmlLink = htmlLink.replace(i18nDocsRegex, `${baseDocsPart}en/VERSION/`);
     } else {

--- a/packages/docusaurus-1.x/package.json
+++ b/packages/docusaurus-1.x/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "docusaurus",
+  "name": "@unboundedsystems/docusaurus",
   "description": "Easy to Maintain Open Source Documentation Websites",
-  "version": "1.12.0",
+  "version": "1.12.0-unb.1",
   "license": "MIT",
   "keywords": [
     "documentation",


### PR DESCRIPTION
Fixes issue where deleting doc files in the latest version of docs causes broken links in older versions.

NOTE: There still needs to be an additional piece to this fix to correctly work with i18n URLs.