### PR TITLE
Improve page meta tags - description & social cards

### DIFF
--- a/packages/docusaurus-1.x/lib/core/BlogPostLayout.js
+++ b/packages/docusaurus-1.x/lib/core/BlogPostLayout.js
@@ -118,6 +118,7 @@ class BlogPostLayout extends React.Component {
         description={this.getDescription()}
         config={this.props.config}
         authorTwitter={post.authorTwitter}
+        image={post.image}
         metadata={{blog: true}}>
         <div className="docMainWrapper wrapper">
           <BlogSidebar

--- a/packages/docusaurus-1.x/lib/core/BlogPostLayout.js
+++ b/packages/docusaurus-1.x/lib/core/BlogPostLayout.js
@@ -117,6 +117,7 @@ class BlogPostLayout extends React.Component {
         language="en"
         description={this.getDescription()}
         config={this.props.config}
+        authorTwitter={post.authorTwitter}
         metadata={{blog: true}}>
         <div className="docMainWrapper wrapper">
           <BlogSidebar

--- a/packages/docusaurus-1.x/lib/core/BlogPostLayout.js
+++ b/packages/docusaurus-1.x/lib/core/BlogPostLayout.js
@@ -15,9 +15,9 @@ const Site = require('./Site.js');
 const OnPageNav = require('./nav/OnPageNav.js');
 const utils = require('./utils.js');
 
-function BlogCommentSystem({ config }) {
+function BlogCommentSystem({config}) {
   if (!config.commentSystem || !config.commentSystem.blog) return null;
-  if (config.commentSystem.type === "commento") {
+  if (config.commentSystem.type === 'commento') {
     return (
       <div className="commentSection">
         <div id="commento" />

--- a/packages/docusaurus-1.x/lib/core/DocsLayout.js
+++ b/packages/docusaurus-1.x/lib/core/DocsLayout.js
@@ -9,6 +9,7 @@ const classNames = require('classnames');
 const path = require('path');
 const React = require('react');
 const url = require('url');
+const Remarkable = require('remarkable');
 
 const Container = require('./Container.js');
 const Doc = require('./Doc.js');
@@ -18,6 +19,43 @@ const Site = require('./Site.js');
 const translation = require('../server/translation.js');
 const docs = require('../server/docs.js');
 const {idx, getGitLastUpdatedTime, getGitLastUpdatedBy} = require('./utils.js');
+
+const MAX_DESCRIPTION = 160; // Max length for HTML description meta tag
+
+function findTextChunks(doc, callback, headings) {
+  let heading = 0;
+
+  function processChunks(chunks) {
+    const len = chunks.length;
+    for (let i = 0; i < len; i++) {
+      const c = chunks[i];
+      switch (c.type) {
+        case 'heading_open':
+          heading++;
+          break;
+        case 'heading_close':
+          heading--;
+          break;
+        case 'text':
+        case 'code':
+          if (headings || heading === 0) {
+            // callback returns true to keep iterating
+            if (!callback(c.content)) return false;
+          }
+          break;
+        default:
+          break;
+      }
+      if (c.children) {
+        if (!processChunks(c.children)) return false;
+      }
+    }
+    return true; // Keep iterating
+  }
+
+  const md = new Remarkable();
+  processChunks(md.parse(doc, {}));
+}
 
 // component used to generate whole webpage for docs, including sidebar/header/footer
 class DocsLayout extends React.Component {
@@ -33,6 +71,39 @@ class DocsLayout extends React.Component {
       relativeHref,
     );
   };
+
+  getDescription() {
+    let desc = this.props.metadata.description || '';
+    if (desc) {
+      if (desc.length > MAX_DESCRIPTION) {
+        console.log(
+          `WARNING: meta description longer than maximum of ` +
+            `${MAX_DESCRIPTION} characters [` +
+            `${this.props.metadata.source || this.props.metadata.id}]`,
+        );
+      }
+      return this.props.metadata.description;
+    }
+
+    findTextChunks(this.props.children, text => {
+      desc +=
+        ' ' +
+        text
+          .replace(/<!--.*?-->/g, '') // Remove HTML comments
+          .replace(/<[a-z/][^>]*>/gi, '') // Remove HTML tags
+          .replace(/"/g, ''); // Double quote not legal in description
+      desc = desc
+        .replace(/\s+/g, ' ') // Replace returns & multiple spaces with one space
+        .trim();
+      // Return true to keep getting more text
+      return desc.length < MAX_DESCRIPTION;
+    });
+
+    if (desc.length <= MAX_DESCRIPTION) return desc;
+
+    // Truncate at the last word boundary
+    return desc.substr(0, desc.lastIndexOf(' ', MAX_DESCRIPTION));
+  }
 
   render() {
     const metadata = this.props.metadata;
@@ -88,7 +159,7 @@ class DocsLayout extends React.Component {
           separateOnPageNav: hasOnPageNav,
         })}
         title={title}
-        description={content.trim().split('\n')[0]}
+        description={this.getDescription()}
         language={metadata.language}
         version={metadata.version}
         metadata={metadata}>

--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -62,6 +62,9 @@ class Head extends React.Component {
             content={siteUrl + this.props.config.twitterImage}
           />
         )}
+        {this.props.authorTwitter && (
+          <meta name="twitter:creator" content={this.props.authorTwitter} />
+        )}
         {this.props.config.noIndex && <meta name="robots" content="noindex" />}
         {this.props.redirect && (
           <meta httpEquiv="refresh" content={`0; URL=${this.props.redirect}`} />

--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -59,6 +59,12 @@ class Head extends React.Component {
         {this.props.authorTwitter && (
           <meta name="twitter:creator" content={this.props.authorTwitter} />
         )}
+        {this.props.config.twitterUsername && (
+          <meta
+            name="twitter:site"
+            content={this.props.config.twitterUsername}
+          />
+        )}
         {this.props.config.noIndex && <meta name="robots" content="noindex" />}
         {this.props.redirect && (
           <meta httpEquiv="refresh" content={`0; URL=${this.props.redirect}`} />

--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -56,7 +56,7 @@ class Head extends React.Component {
         <meta property="og:url" content={this.props.url} />
         <meta property="og:description" content={this.props.description} />
         {ogImage && <meta property="og:image" content={siteUrl + ogImage} />}
-        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:card" content="summary_large_image" />
         {twitterImage && (
           <meta name="twitter:image" content={siteUrl + twitterImage} />
         )}

--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -30,6 +30,7 @@ class Head extends React.Component {
     const siteUrl = `${(
       this.props.config.url + this.props.config.baseUrl
     ).replace(/\/+$/, '')}/`;
+    const ogSiteName = this.props.config.ogSiteName || this.props.config.title;
     const ogImage = this.props.image || this.props.config.ogImage;
     const twitterImage = this.props.image || this.props.config.twitterImage;
 
@@ -49,6 +50,7 @@ class Head extends React.Component {
         )}
         <meta property="og:title" content={this.props.title} />
         <meta property="og:type" content="website" />
+        <meta property="og:site_name" content={ogSiteName} />
         <meta property="og:url" content={this.props.url} />
         <meta property="og:description" content={this.props.description} />
         {ogImage && <meta property="og:image" content={siteUrl + ogImage} />}

--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -30,6 +30,8 @@ class Head extends React.Component {
     const siteUrl = `${(
       this.props.config.url + this.props.config.baseUrl
     ).replace(/\/+$/, '')}/`;
+    const ogImage = this.props.image || this.props.config.ogImage;
+    const twitterImage = this.props.image || this.props.config.twitterImage;
 
     return (
       <head>
@@ -49,18 +51,10 @@ class Head extends React.Component {
         <meta property="og:type" content="website" />
         <meta property="og:url" content={this.props.url} />
         <meta property="og:description" content={this.props.description} />
-        {this.props.config.ogImage && (
-          <meta
-            property="og:image"
-            content={siteUrl + this.props.config.ogImage}
-          />
-        )}
+        {ogImage && <meta property="og:image" content={siteUrl + ogImage} />}
         <meta name="twitter:card" content="summary" />
-        {this.props.config.twitterImage && (
-          <meta
-            name="twitter:image"
-            content={siteUrl + this.props.config.twitterImage}
-          />
+        {twitterImage && (
+          <meta name="twitter:image" content={siteUrl + twitterImage} />
         )}
         {this.props.authorTwitter && (
           <meta name="twitter:creator" content={this.props.authorTwitter} />

--- a/packages/docusaurus-1.x/lib/core/Head.js
+++ b/packages/docusaurus-1.x/lib/core/Head.js
@@ -32,6 +32,8 @@ class Head extends React.Component {
     ).replace(/\/+$/, '')}/`;
     const ogSiteName = this.props.config.ogSiteName || this.props.config.title;
     const ogImage = this.props.image || this.props.config.ogImage;
+    const ogType =
+      this.props.metadata && this.props.metadata.blog ? 'article' : 'website';
     const twitterImage = this.props.image || this.props.config.twitterImage;
 
     return (
@@ -49,7 +51,7 @@ class Head extends React.Component {
           <meta name="docsearch:language" content={this.props.language} />
         )}
         <meta property="og:title" content={this.props.title} />
-        <meta property="og:type" content="website" />
+        <meta property="og:type" content={ogType} />
         <meta property="og:site_name" content={ogSiteName} />
         <meta property="og:url" content={this.props.url} />
         <meta property="og:description" content={this.props.description} />

--- a/packages/docusaurus-1.x/lib/core/Site.js
+++ b/packages/docusaurus-1.x/lib/core/Site.js
@@ -68,6 +68,7 @@ class Site extends React.Component {
           config={this.props.config}
           description={description}
           image={this.props.image}
+          metadata={this.props.metadata}
           title={title}
           url={url}
           language={this.props.language}

--- a/packages/docusaurus-1.x/lib/core/Site.js
+++ b/packages/docusaurus-1.x/lib/core/Site.js
@@ -64,6 +64,7 @@ class Site extends React.Component {
     return (
       <html lang={this.props.language}>
         <Head
+          authorTwitter={this.props.authorTwitter}
           config={this.props.config}
           description={description}
           title={title}

--- a/packages/docusaurus-1.x/lib/core/Site.js
+++ b/packages/docusaurus-1.x/lib/core/Site.js
@@ -67,6 +67,7 @@ class Site extends React.Component {
           authorTwitter={this.props.authorTwitter}
           config={this.props.config}
           description={description}
+          image={this.props.image}
           title={title}
           url={url}
           language={this.props.language}

--- a/packages/docusaurus-1.x/lib/core/nav/HeaderNav.js
+++ b/packages/docusaurus-1.x/lib/core/nav/HeaderNav.js
@@ -215,7 +215,7 @@ class HeaderNav extends React.Component {
     } else if (link.blog) {
       // set link to blog url
       href = `${this.props.baseUrl}blog/`;
-    } 
+    }
     const itemClasses = classNames({
       siteNavGroupActive:
         (link.doc && docGroupActive) || (link.blog && this.props.current.blog),
@@ -227,11 +227,14 @@ class HeaderNav extends React.Component {
     const i18n = translation[this.props.language];
     return (
       <li key={`${link.label}page`} className={itemClasses}>
-        { link.raw 
-          ? link.raw 
-          : <a href={href} target={link.external ? '_blank' : '_self'}>
-              {idx(i18n, ['localized-strings', 'links', link.label]) || link.label}
-            </a> }
+        {link.raw ? (
+          link.raw
+        ) : (
+          <a href={href} target={link.external ? '_blank' : '_self'}>
+            {idx(i18n, ['localized-strings', 'links', link.label]) ||
+              link.label}
+          </a>
+        )}
       </li>
     );
   }

--- a/packages/docusaurus-1.x/lib/server/docs.js
+++ b/packages/docusaurus-1.x/lib/server/docs.js
@@ -61,9 +61,6 @@ function mdToHtmlify(oldContent, mdToHtml, metadata, siteConfig) {
     if (fencedBlock) return line;
 
     let modifiedLine = line;
-    const deb = (...args) => {
-      if (false && modifiedLine.includes('externaldockerhost')) console.log(...args);
-    }
     /* Replace inline-style links or reference-style links e.g:
     This is [Document 1](doc1.md) -> we replace this doc1.md with correct link
     [doc1]: doc1.md -> we replace this doc1.md with correct link
@@ -71,33 +68,27 @@ function mdToHtmlify(oldContent, mdToHtml, metadata, siteConfig) {
     const mdRegex = /(?:(?:\]\()|(?:\]:\s?))(?!https)([^'")\]\s>]+\.md)/g;
     let mdMatch = mdRegex.exec(modifiedLine);
     while (mdMatch !== null) {
-      deb('\nMatch: ', mdMatch[1]);
-      deb('  LINE: ', modifiedLine);
-      deb('  version', metadata.version);
-      deb('  meta source: ', metadata.source);
-      // for (const k of Object.keys(mdToHtml)) {
-      //   if (k.includes('externaldockerhost')) deb("  meta:", k, "->", mdToHtml[k]);
-      // }
       /* Replace it to correct html link */
       const docsSource = metadata.version
         ? metadata.source.replace(/version-.*?\//, '')
         : metadata.source;
-      deb('  docs source: ', docsSource);
+      /* eslint-disable no-loop-func */
       const resolvers = [
         () => resolve(docsSource, mdMatch[1]),
         () => mdMatch[1],
         () => metadata.version && resolve(metadata.source, mdMatch[1]),
-      ]
+      ];
       const resolveLink = () => {
+        // eslint-disable-next-line no-restricted-syntax
         for (const r of resolvers) {
           const p = r();
-          deb('  Trying path:', p);
           const link = mdToHtml[p];
           if (link) return link;
         }
-      }
+        return undefined;
+      };
+      /* eslint-enable no-loop-func */
       let htmlLink = resolveLink();
-      deb('  Resolved:', htmlLink);
       if (htmlLink) {
         htmlLink = getPath(htmlLink, siteConfig.cleanUrl);
         htmlLink = htmlLink.replace('/en/', `/${metadata.language}/`);

--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -36,6 +36,7 @@ const SupportedHeaderFields = new Set([
   'hide_title',
   'layout',
   'custom_edit_url',
+  'description',
 ]);
 
 let allSidebars;

--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -37,6 +37,7 @@ const SupportedHeaderFields = new Set([
   'layout',
   'custom_edit_url',
   'description',
+  'image',
 ]);
 
 let allSidebars;


### PR DESCRIPTION
This set of commits:
- Adds the ability for a blog article to manually specify its meta description
- Improves the automatic creation of a default meta description by ignoring things that should not be in the description
- Adds the "creator" tag for Twitter cards (author's Twitter)
- Adds the ability for a blog article to manually specify its social card image
- Adds the "site" tag for Twitter cards (site's Twitter)
- Adds the Open Graph "site_name" tag