### PR TITLE
Ensure versioned doc pages have a left sidebar

### DIFF
--- a/packages/docusaurus-1.x/lib/server/readMetadata.js
+++ b/packages/docusaurus-1.x/lib/server/readMetadata.js
@@ -336,6 +336,13 @@ function generateMetadataDocs() {
           (env.translation.enabled ? `${metadata.language}-` : '') +
           order[id].previous;
       }
+    } else if (metadata.parent_id && order[metadata.parent_id]) {
+      const parent = order[metadata.parent_id];
+
+      metadata.sidebar = parent.sidebar;
+      metadata.category = parent.category;
+      metadata.subcategory = parent.subcategory;
+      metadata.order = parent.order;
     }
     metadatas[metadata.id] = metadata;
   });

--- a/packages/docusaurus-1.x/lib/version.js
+++ b/packages/docusaurus-1.x/lib/version.js
@@ -134,6 +134,9 @@ files.forEach(file => {
   const targetFile = subDir
     ? `${versionFolder}/${subDir}/${path.basename(file)}`
     : `${versionFolder}/${path.basename(file)}`;
+  if (metadata.parent_id) {
+    metadata.parent_id = `version-${version}-${metadata.parent_id}`;
+  }
 
   writeFileAndCreateFolder(
     targetFile,

--- a/packages/docusaurus-1.x/lib/version.js
+++ b/packages/docusaurus-1.x/lib/version.js
@@ -85,7 +85,7 @@ if (versions.includes(version)) {
 function makeHeader(metadata) {
   let header = '---\n';
   Object.keys(metadata).forEach(key => {
-    header += `${key}: ${metadata[key]}\n`;
+    header += `${key}: ${JSON.stringify(metadata[key])}\n`;
   });
   header += '---\n';
   return header;


### PR DESCRIPTION
Primary issue: The recent changes to add the left sidebar for **all** doc pages (even those that are not directly linked to) worked fine for `next` docs, but were not working for versioned docs.

Fix was two parts:

1. When creating a new version of docs, perform the same ID mapping on `parent_id` metadata as is performed on `id`.

2. The metadata for a versioned doc is created in a different place than the metadata for a `next` doc. So the logic to find and add the `sidebar`, `category` and related fields was also needed there.

Secondary issue: Possible issues with parsing metadata headers for versioned docs

This change wasn't prompted by anything specific that wasn't working. But when running the docusaurus-version command, any string quoting that may have been present in the file metadata headers is stripped for the newly created versioned files. Since the metadata headers are (partially) parsed as JSON, it is safer to always write them as JSON.
